### PR TITLE
Updated Sponsors and Timeline

### DIFF
--- a/src/Components/Home/Sponsors/Sponsors.scss
+++ b/src/Components/Home/Sponsors/Sponsors.scss
@@ -89,7 +89,13 @@
   align-self: center;
   justify-self: center;
   animation: glow 4s linear infinite;
+  @media screen and (max-width: $QHD-screen){
+    height: 112px;
+  }
   @media screen and (max-width: $mobile-view) {
     height: 80px;
+  }
+  @media screen and (max-width: $small-mobile){
+    height: 60px;
   }
 }

--- a/src/Components/Timeline/Timeline.scss
+++ b/src/Components/Timeline/Timeline.scss
@@ -93,24 +93,26 @@
     border-radius: 50%;
     bottom: 7%;
     z-index: 1000;
+    justify-content: center;
+    align-content: center;
 
     &:hover {
         background-color: #ffffff;
         color: #5EC9F8;
     }
 
-    @media screen and (max-width: 980px) {
-        margin-left: auto;
-        margin-right: auto;
-        width: 42px;
-        height: 42px;
-        left: 0;
-        right: 0;
-    }
-
     @media only screen and (max-width: 1170px) {
         top: 20px;
     }
+    @media screen and (max-width: 980px) {
+        display: flex;
+        margin-left: auto;
+        width: 30px;
+        height: 36px;
+        top: 87%;
+        right: 5%;
+    }
+
 }
 
 .eventLink {

--- a/src/scss/abstracts/_variables.scss
+++ b/src/scss/abstracts/_variables.scss
@@ -7,3 +7,4 @@ $color-moon: #52f09c;
 $mobile-view: 1000px;
 $QHD-screen:1440px;
 $hd-screen: 1366px;
+$small-mobile: 400px;


### PR DESCRIPTION
Updated the image size of sponsors in 1366px resolution.
Before:
![Screenshot (21)](https://user-images.githubusercontent.com/48920341/75140014-10bcea00-5714-11ea-9216-133e4201ad35.png)
After:
![Screenshot (23)](https://user-images.githubusercontent.com/48920341/75140097-41048880-5714-11ea-9bc0-e1cf06e5677c.png)

Updated the image size of sponsors for mobiles with small screen size.
![Screenshot (22)](https://user-images.githubusercontent.com/48920341/75140201-714c2700-5714-11ea-9ba3-d98edc2e9274.png)

Relocated download button to bottom right corner in mobile view
![Screenshot (24)](https://user-images.githubusercontent.com/48920341/75181221-c3686900-5763-11ea-97bd-940c2b296d7e.png)

